### PR TITLE
refactor: import modules adapters layer

### DIFF
--- a/adapters/src/exceptions/repository/appointment.py
+++ b/adapters/src/exceptions/repository/appointment.py
@@ -1,4 +1,4 @@
-from adapters.src.exceptions.repository.base import RepositoryException
+from .base import RepositoryException
 
 
 class AppointmentRepositoryException(RepositoryException):

--- a/adapters/src/exceptions/repository/email_sender.py
+++ b/adapters/src/exceptions/repository/email_sender.py
@@ -1,4 +1,4 @@
-from adapters.src.exceptions.repository.base import RepositoryException
+from .base import RepositoryException
 
 
 class EmailSenderRepositoryException(RepositoryException):

--- a/adapters/src/exceptions/repository/product.py
+++ b/adapters/src/exceptions/repository/product.py
@@ -1,4 +1,4 @@
-from adapters.src.exceptions.repository.base import RepositoryException
+from .base import RepositoryException
 
 
 class ProductRepositoryException(RepositoryException):

--- a/adapters/src/repositories/__init__.py
+++ b/adapters/src/repositories/__init__.py
@@ -1,0 +1,4 @@
+from .email_sender import SMTPEmailSenderRepository
+from .memory import (MemoryAppointmentRepository, MemoryEmailSenderRepository,
+                     MemoryProductRepository)
+from .sql import SQLAppointmentRepository, SQLProductRepository

--- a/adapters/src/repositories/email_sender/__init__.py
+++ b/adapters/src/repositories/email_sender/__init__.py
@@ -1,0 +1,1 @@
+from .email_sender_adapter import SMTPEmailSenderRepository

--- a/adapters/src/repositories/memory/__init__.py
+++ b/adapters/src/repositories/memory/__init__.py
@@ -1,0 +1,3 @@
+from .memory_appointment_repository import MemoryAppointmentRepository
+from .memory_email_sender_repository import MemoryEmailSenderRepository
+from .memory_product_repository import MemoryProductRepository

--- a/adapters/src/repositories/sql/__init__.py
+++ b/adapters/src/repositories/sql/__init__.py
@@ -1,0 +1,4 @@
+from .config_db.session_manager import Session
+from .config_db.sql_connection import SQLConnection
+from .sql_appointment_adapter import SQLAppointmentRepository
+from .sql_product_adapter import SQLProductRepository

--- a/adapters/src/repositories/sql/sql_appointment_adapter.py
+++ b/adapters/src/repositories/sql/sql_appointment_adapter.py
@@ -1,7 +1,6 @@
 from typing import List, Optional
 
-from adapters.src.exceptions.repository.appointment import \
-    AppointmentRepositoryException
+from adapters.src.exceptions import AppointmentRepositoryException
 from core.src.models.appointment import Appointment
 from core.src.repository.appointment_repository import AppointmentRepository
 

--- a/adapters/src/repositories/sql/sql_product_adapter.py
+++ b/adapters/src/repositories/sql/sql_product_adapter.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-from adapters.src.exceptions.repository.product import \
-    ProductRepositoryException
+from adapters.src.exceptions import ProductRepositoryException
 from core.src.models.product import Product
 from core.src.repository.product_repository import ProductRepository
 

--- a/adapters/src/repositories/sql/tables/__init__.py
+++ b/adapters/src/repositories/sql/tables/__init__.py
@@ -1,0 +1,2 @@
+from .appointment import AppointmentRecord
+from .product import ProductRecord

--- a/adapters/tests/repositories/sql/appointment/test_create_appointment_sql_adapter.py
+++ b/adapters/tests/repositories/sql/appointment/test_create_appointment_sql_adapter.py
@@ -1,10 +1,7 @@
 import pytest
 
-from adapters.src.exceptions.repository.appointment import \
-    AppointmentRepositoryException
-from adapters.src.repositories.sql.config_db.session_manager import Session
-from adapters.src.repositories.sql.sql_appointment_adapter import \
-    SQLAppointmentRepository
+from adapters.src.exceptions import AppointmentRepositoryException
+from adapters.src.repositories.sql import Session, SQLAppointmentRepository
 from core.src.models.appointment import Appointment
 
 

--- a/adapters/tests/repositories/sql/appointment/test_get_all_appointments_sql_adapter.py
+++ b/adapters/tests/repositories/sql/appointment/test_get_all_appointments_sql_adapter.py
@@ -1,10 +1,7 @@
 import pytest
 
-from adapters.src.exceptions.repository.appointment import \
-    AppointmentRepositoryException
-from adapters.src.repositories.sql.config_db.session_manager import Session
-from adapters.src.repositories.sql.sql_appointment_adapter import \
-    SQLAppointmentRepository
+from adapters.src.exceptions import AppointmentRepositoryException
+from adapters.src.repositories.sql import Session, SQLAppointmentRepository
 from core.src.models.appointment import Appointment
 
 

--- a/adapters/tests/repositories/sql/appointment/test_get_by_date_and_time_appointment_sql_adapter.py
+++ b/adapters/tests/repositories/sql/appointment/test_get_by_date_and_time_appointment_sql_adapter.py
@@ -1,10 +1,7 @@
 import pytest
 
-from adapters.src.exceptions.repository.appointment import \
-    AppointmentRepositoryException
-from adapters.src.repositories.sql.config_db.session_manager import Session
-from adapters.src.repositories.sql.sql_appointment_adapter import \
-    SQLAppointmentRepository
+from adapters.src.exceptions import AppointmentRepositoryException
+from adapters.src.repositories.sql import Session, SQLAppointmentRepository
 from core.src.models.appointment import Appointment
 
 

--- a/adapters/tests/repositories/sql/product/test_create_product_sql_adapter.py
+++ b/adapters/tests/repositories/sql/product/test_create_product_sql_adapter.py
@@ -1,10 +1,7 @@
 import pytest
 
-from adapters.src.exceptions.repository.product import \
-    ProductRepositoryException
-from adapters.src.repositories.sql.config_db.session_manager import Session
-from adapters.src.repositories.sql.sql_product_adapter import \
-    SQLProductRepository
+from adapters.src.exceptions import ProductRepositoryException
+from adapters.src.repositories.sql import Session, SQLProductRepository
 from core.src.models.product import Product
 
 

--- a/adapters/tests/repositories/sql/product/test_get_all_products_sql_adapter.py
+++ b/adapters/tests/repositories/sql/product/test_get_all_products_sql_adapter.py
@@ -1,10 +1,7 @@
 import pytest
 
-from adapters.src.exceptions.repository.product import \
-    ProductRepositoryException
-from adapters.src.repositories.sql.config_db.session_manager import Session
-from adapters.src.repositories.sql.sql_product_adapter import \
-    SQLProductRepository
+from adapters.src.exceptions import ProductRepositoryException
+from adapters.src.repositories.sql import Session, SQLProductRepository
 from core.src.models.product import Product
 
 

--- a/adapters/tests/repositories/sql/product/test_get_by_name_sql_adapter.py
+++ b/adapters/tests/repositories/sql/product/test_get_by_name_sql_adapter.py
@@ -1,10 +1,7 @@
 import pytest
 
-from adapters.src.exceptions.repository.product import \
-    ProductRepositoryException
-from adapters.src.repositories.sql.config_db.session_manager import Session
-from adapters.src.repositories.sql.sql_product_adapter import \
-    SQLProductRepository
+from adapters.src.exceptions import ProductRepositoryException
+from adapters.src.repositories.sql import Session, SQLProductRepository
 from core.src.models.product import Product
 
 


### PR DESCRIPTION
#### 🤔 Why?
- Modify import modules in adapters layer to make shorter them.

#### 🛠 What I changed:
- adapters/

#### 🗃️ Notion ticket:
- [Ticket](https://www.notion.so/4801289a207f47d0a24135fc813d0bc8?v=9183b131462a4e06aa2fdb997dc89c3a&p=06e6ac48922d4c398cc8666e653dba4a&pm=s)

#### 🚦 Functional Testing Results:
![image](https://github.com/HaroldR23/dental-lab-website-backend/assets/107003395/1e6a67e1-199f-4970-9b90-c89ccf919cad)
