### PR TITLE
refactor: import moduls api layer

### DIFF
--- a/adapters/src/exceptions/repository/__init__.py
+++ b/adapters/src/exceptions/repository/__init__.py
@@ -1,0 +1,1 @@
+from .base import RepositoryException

--- a/adapters/src/repositories/sql/__init__.py
+++ b/adapters/src/repositories/sql/__init__.py
@@ -1,4 +1,4 @@
-from .config_db.session_manager import Session
+from .config_db.session_manager import SessionManager
 from .config_db.sql_connection import SQLConnection
 from .sql_appointment_adapter import SQLAppointmentRepository
 from .sql_product_adapter import SQLProductRepository

--- a/adapters/tests/repositories/sql/appointment/test_create_appointment_sql_adapter.py
+++ b/adapters/tests/repositories/sql/appointment/test_create_appointment_sql_adapter.py
@@ -1,7 +1,8 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from adapters.src.exceptions import AppointmentRepositoryException
-from adapters.src.repositories.sql import Session, SQLAppointmentRepository
+from adapters.src.repositories.sql import SQLAppointmentRepository
 from core.src.models.appointment import Appointment
 
 

--- a/adapters/tests/repositories/sql/appointment/test_get_all_appointments_sql_adapter.py
+++ b/adapters/tests/repositories/sql/appointment/test_get_all_appointments_sql_adapter.py
@@ -1,7 +1,8 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from adapters.src.exceptions import AppointmentRepositoryException
-from adapters.src.repositories.sql import Session, SQLAppointmentRepository
+from adapters.src.repositories.sql import SQLAppointmentRepository
 from core.src.models.appointment import Appointment
 
 

--- a/adapters/tests/repositories/sql/appointment/test_get_by_date_and_time_appointment_sql_adapter.py
+++ b/adapters/tests/repositories/sql/appointment/test_get_by_date_and_time_appointment_sql_adapter.py
@@ -1,7 +1,8 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from adapters.src.exceptions import AppointmentRepositoryException
-from adapters.src.repositories.sql import Session, SQLAppointmentRepository
+from adapters.src.repositories.sql import SQLAppointmentRepository
 from core.src.models.appointment import Appointment
 
 

--- a/adapters/tests/repositories/sql/product/test_create_product_sql_adapter.py
+++ b/adapters/tests/repositories/sql/product/test_create_product_sql_adapter.py
@@ -1,7 +1,8 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from adapters.src.exceptions import ProductRepositoryException
-from adapters.src.repositories.sql import Session, SQLProductRepository
+from adapters.src.repositories.sql import SQLProductRepository
 from core.src.models.product import Product
 
 

--- a/adapters/tests/repositories/sql/product/test_get_all_products_sql_adapter.py
+++ b/adapters/tests/repositories/sql/product/test_get_all_products_sql_adapter.py
@@ -1,7 +1,8 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from adapters.src.exceptions import ProductRepositoryException
-from adapters.src.repositories.sql import Session, SQLProductRepository
+from adapters.src.repositories.sql import SQLProductRepository
 from core.src.models.product import Product
 
 

--- a/adapters/tests/repositories/sql/product/test_get_by_name_sql_adapter.py
+++ b/adapters/tests/repositories/sql/product/test_get_by_name_sql_adapter.py
@@ -1,7 +1,8 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from adapters.src.exceptions import ProductRepositoryException
-from adapters.src.repositories.sql import Session, SQLProductRepository
+from adapters.src.repositories.sql import SQLProductRepository
 from core.src.models.product import Product
 
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -3,11 +3,8 @@ from typing import AsyncGenerator
 
 from fastapi import FastAPI
 
-from adapters.src.repositories.sql.config_db import (SessionManager,
-                                                     SQLConnection)
-from api.src.routers.appointment import appointment_router
-from api.src.routers.index import index_router
-from api.src.routers.product import product_router
+from adapters.src.repositories.sql import SessionManager, SQLConnection
+from api.src.routers import appointment_router, index_router, product_router
 
 
 @asynccontextmanager

--- a/api/src/dtos/__init__.py
+++ b/api/src/dtos/__init__.py
@@ -1,0 +1,2 @@
+from .appointment_dto import Appointment
+from .product_dto import Product

--- a/api/src/routers/__init__.py
+++ b/api/src/routers/__init__.py
@@ -1,0 +1,3 @@
+from .appointment import appointment_router
+from .index import index_router
+from .product import product_router

--- a/api/src/routers/appointment.py
+++ b/api/src/routers/appointment.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
 
-from api.src.dtos.appointment_dto import Appointment
+from api.src.dtos import Appointment
 from api.src.routers.index import index_router
 from core.src.use_cases.appointment.create import CreateAppointmentRequest
 from factories.use_cases.appointment import (create_appointment_use_case,

--- a/api/src/routers/product.py
+++ b/api/src/routers/product.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
 
-from api.src.dtos.product_dto import Product
+from api.src.dtos import Product
 from core.src.use_cases.product.create.request import CreateProductRequest
 from factories.use_cases.product import (create_product_use_case,
                                          get_all_products_use_case)

--- a/factories/use_cases/appointment.py
+++ b/factories/use_cases/appointment.py
@@ -7,7 +7,7 @@ from factories.repositories.email_sender import email_sender_repository
 def create_appointment_use_case() -> CreateAppointment:
     return CreateAppointment(
         appointment_repository=sql_appointment_repository(),
-        email_sender_repository=email_sender_repository(),  # TODO: Use the real email repository when it's done
+        email_sender_repository=email_sender_repository(),
     )
 
 


### PR DESCRIPTION
#### 🤔 Why?
- Modify import modules in api layer to make shorter them.

#### 🛠 What I changed:
- api/
- adapters/

#### 🗃️ Notion ticket:
- [Ticket](https://www.notion.so/4801289a207f47d0a24135fc813d0bc8?v=9183b131462a4e06aa2fdb997dc89c3a&p=06e6ac48922d4c398cc8666e653dba4a&pm=s)

#### 🚦 Functional Testing Results:
![image](https://github.com/HaroldR23/dental-lab-website-backend/assets/107003395/538bead6-dc45-4489-9dff-480f483ae2d8)
